### PR TITLE
Add coverage enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests with coverage
+        run: |
+          pytest --cov=. --cov-fail-under=70 -q

--- a/README.md
+++ b/README.md
@@ -20,3 +20,13 @@ This is a simple web game where players press numbered buttons in order. It is i
 - `templates/index.html` – HTML template
 - `static/style.css` – basic styles
 - `requirements.txt` – Python dependencies
+
+## Testing
+
+Run the unit tests with coverage enabled:
+
+```bash
+pytest --cov=. --cov-fail-under=70 -q
+```
+
+The repository includes a GitHub Actions workflow that installs dependencies and runs these tests with coverage reporting automatically on every push and pull request.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 Flask>=2.2
+pytest
+pytest-cov

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,11 @@
+import os
+import sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app import app
+
+
+def test_index_route():
+    with app.test_client() as client:
+        response = client.get('/')
+        assert response.status_code == 200


### PR DESCRIPTION
## Summary
- enforce coverage in CI via `pytest --cov`
- document coverage usage in the README
- install `pytest-cov` dependency

## Testing
- `pytest --cov=. --cov-fail-under=70 -q`

------
https://chatgpt.com/codex/tasks/task_e_6842364ff4908320872065df5b18f53d