### PR TITLE
Add Procfile and port configuration

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn app:app

--- a/app.py
+++ b/app.py
@@ -1,4 +1,5 @@
 from flask import Flask, render_template, request, session, redirect, url_for
+import os
 import random
 
 app = Flask(__name__)
@@ -46,4 +47,5 @@ def restart():
 
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    port = int(os.environ.get("PORT", 5000))
+    app.run(host='0.0.0.0', port=port)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask>=2.2
 pytest
 pytest-cov
+gunicorn


### PR DESCRIPTION
## Summary
- add a `Procfile` for Heroku web process
- configure the Flask app to read the `PORT` environment variable
- include `gunicorn` in requirements for production use

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68423cb920e083209fb5f12c5f6baf6b