### PR TITLE
Fix session reset for new games

### DIFF
--- a/app.py
+++ b/app.py
@@ -44,6 +44,9 @@ def start_level(level: int):
 
 @app.route('/')
 def root():
+    # Always start with a clean session so previous progress doesn't
+    # incorrectly unlock levels for new players.
+    session.clear()
     init_session()
     return redirect(url_for('levels'))
 


### PR DESCRIPTION
## Summary
- ensure any old session data is cleared when the game starts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684247addb508320b29dc580158180d7