### PR TITLE
Fix wrong-order reset in level 2

### DIFF
--- a/app.py
+++ b/app.py
@@ -94,6 +94,8 @@ def index(level):
                     session.modified = True
         elif not valid:
             message = 'Wrong order!'
+            # Reset progress on incorrect number
+            start_level(level)
 
     next_level_enabled = len(session.get('clicked', [])) == total and level < max(LEVEL_NUMBERS)
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -34,5 +34,11 @@
     <div style="margin-top:20px;">
         <a href="{{ url_for('restart') }}">Restart</a>
     </div>
+    <script>
+        const msgEl = document.getElementById('message');
+        if (msgEl && msgEl.textContent.trim() !== '') {
+            setTimeout(() => { msgEl.textContent = ''; }, 1500);
+        }
+    </script>
 </body>
 </html>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -88,3 +88,17 @@ def test_reverse_order_level_3():
             resp = client.post('/level/3', data={'num': str(n)})
         assert b'Level complete!' in resp.data
 
+
+def test_wrong_order_resets_level_2():
+    """Level 2 should reset when a wrong number is pressed."""
+    with app.test_client() as client:
+        client.get('/level/2')
+        client.post('/level/2', data={'num': '1'})
+        resp = client.post('/level/2', data={'num': '3'})
+        assert b'Wrong order!' in resp.data
+        with client.session_transaction() as sess:
+            assert sess.get('clicked') == []
+        resp = client.post('/level/2', data={'num': '1'})
+        with client.session_transaction() as sess:
+            assert sess.get('clicked') == [1]
+


### PR DESCRIPTION
## Summary
- reset progress on invalid number selection
- show transient messages for feedback
- add regression test for level reset on wrong order

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684247cbf48c8320a7aa93b6091654a1