### PR TITLE
Fix unsolved level not resetting after visiting menu

### DIFF
--- a/app.py
+++ b/app.py
@@ -51,6 +51,13 @@ def root():
 @app.route('/levels')
 def levels():
     init_session()
+    # Reset progress for an unsolved level when returning to the menu
+    current = session.get('level')
+    if current is not None and current not in session.get('completed', []):
+        session.pop('level', None)
+        session.pop('numbers', None)
+        session.pop('clicked', None)
+        session.modified = True
     min_level = min(LEVEL_NUMBERS)
     max_level = max(LEVEL_NUMBERS)
     completed = set(session.get('completed', []))

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -88,3 +88,16 @@ def test_reverse_order_level_3():
             resp = client.post('/level/3', data={'num': str(n)})
         assert b'Level complete!' in resp.data
 
+
+def test_menu_resets_unsolved_level():
+    """Visiting the menu should reset progress for unsolved levels."""
+    with app.test_client() as client:
+        client.get('/level/1')
+        client.post('/level/1', data={'num': '1'})
+        # Go back to the level selection menu
+        client.get('/levels')
+        # Re-enter the same level; progress should be cleared
+        client.get('/level/1')
+        with client.session_transaction() as sess:
+            assert sess.get('clicked') == []
+


### PR DESCRIPTION
## Summary
- clear unsolved level state when menu is opened
- test returning to menu resets unsolved level progress

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684248081b34832081500d000a957df7