### PR TITLE
Fix progress loss after server restart

### DIFF
--- a/app.py
+++ b/app.py
@@ -44,9 +44,15 @@ def start_level(level: int):
 
 @app.route('/')
 def root():
-    # Always start with a clean session so previous progress doesn't
-    # incorrectly unlock levels for new players.
-    session.clear()
+    """Entry point for the game.
+
+    We used to wipe the session here to avoid leaking progress between
+    different users. However the session is stored client side so clearing it
+    would also erase a player's progress whenever they visit the root URL
+    again (for example after a server restart).  We now simply ensure the
+    session structure exists without discarding existing data so progress
+    persists across restarts.
+    """
     init_session()
     return redirect(url_for('levels'))
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -113,3 +113,14 @@ def test_wrong_order_resets_level_2():
         with client.session_transaction() as sess:
             assert sess.get('clicked') == [1]
 
+
+def test_root_does_not_clear_progress():
+    """Visiting the root URL should not wipe existing session progress."""
+    with app.test_client() as client:
+        client.get('/level/0')
+        client.post('/level/0', data={'num': '1'})
+        # Visiting '/' used to clear the session. Ensure progress persists.
+        client.get('/')
+        with client.session_transaction() as sess:
+            assert 0 in sess.get('completed', [])
+


### PR DESCRIPTION
## Summary
- ensure root handler doesn't wipe session progress
- add regression test for retaining progress when visiting root

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68424d1dd3208320907857dc88325c60