### PR TITLE
Fix message overlay

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -19,9 +19,20 @@ button.number {
 }
 
 #message {
-    margin-top: 20px;
+    position: fixed;
+    bottom: 100px;
+    left: 50%;
+    transform: translateX(-50%) translateY(20px);
+    transition: transform 0.3s ease-out;
+    background: #fff;
+    padding: 10px 20px;
+    border-radius: 5px;
     font-size: 18px;
     color: #333;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+    pointer-events: none;
+    z-index: 1000;
+    display: none;
 }
 
 .menu {

--- a/templates/index.html
+++ b/templates/index.html
@@ -37,7 +37,15 @@
     <script>
         const msgEl = document.getElementById('message');
         if (msgEl && msgEl.textContent.trim() !== '') {
-            setTimeout(() => { msgEl.textContent = ''; }, 1500);
+            msgEl.style.display = 'block';
+            requestAnimationFrame(() => {
+                msgEl.style.transform = 'translateX(-50%) translateY(0)';
+            });
+            setTimeout(() => {
+                msgEl.style.display = 'none';
+                msgEl.textContent = '';
+                msgEl.style.transform = 'translateX(-50%) translateY(20px)';
+            }, 1500);
         }
     </script>
 </body>


### PR DESCRIPTION
## Summary
- stop bottom menu from shifting when showing messages
- display pop-up messages over the buttons with subtle shadow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68424d1fa9a88320b6786c2371539e68