### PR TITLE
Center popup over grid

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -10,6 +10,7 @@ body {
     display: grid;
     grid-gap: 10px;
     margin-top: 20px;
+    position: relative;
 }
 
 button.number {
@@ -19,10 +20,10 @@ button.number {
 }
 
 #message {
-    position: fixed;
-    bottom: 100px;
+    position: absolute;
+    top: 50%;
     left: 50%;
-    transform: translateX(-50%) translateY(20px);
+    transform: translate(-50%, -50%) scale(0.95);
     transition: transform 0.3s ease-out;
     background: #fff;
     padding: 10px 20px;

--- a/templates/index.html
+++ b/templates/index.html
@@ -21,8 +21,8 @@
             <button name="num" value="{{ num }}" class="number" {% if num in clicked %}disabled{% endif %}>{{ num }}</button>
         </form>
         {% endfor %}
+        <div id="message">{{ message }}</div>
     </div>
-    <div id="message">{{ message }}</div>
     <div class="menu">
         <a href="{{ url_for('levels') }}">Menu</a>
         {% if next_level_enabled %}
@@ -39,12 +39,12 @@
         if (msgEl && msgEl.textContent.trim() !== '') {
             msgEl.style.display = 'block';
             requestAnimationFrame(() => {
-                msgEl.style.transform = 'translateX(-50%) translateY(0)';
+                msgEl.style.transform = 'translate(-50%, -50%) scale(1)';
             });
             setTimeout(() => {
                 msgEl.style.display = 'none';
                 msgEl.textContent = '';
-                msgEl.style.transform = 'translateX(-50%) translateY(20px)';
+                msgEl.style.transform = 'translate(-50%, -50%) scale(0.95)';
             }, 1500);
         }
     </script>


### PR DESCRIPTION
## Summary
- center the popup in the middle of the grid
- animate popup scale and move on show/hide

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68424f4386988320965864b63cf98151